### PR TITLE
Add server request types, closes #30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ all:
 	@echo ""
 	@echo "  run-api-bg: run the API server in the background"
 	@echo ""
+	@echo "  run-mock: run the mock API server"
+	@echo ""
+	@echo "  run-mock-bg: run the mock API server in the background"
+	@echo ""
 	@echo "  kill-api: kill the API server"
 	@echo ""
 	@echo "  test: run all unit tests in the repo"
@@ -32,6 +36,12 @@ run-api:
 
 run-api-bg:
 	go run api/main.go &
+
+run-mock:
+	go run api/mock-api/main.go
+
+run-mock-bg:
+	go run api/mock-api/main.go &
 
 kill-api:
 	./hack/kill_server.sh

--- a/api/mock-api/main.go
+++ b/api/mock-api/main.go
@@ -1,5 +1,7 @@
 package main
 
+// TODO: extend mock server, this is currently an exact copy of api/main.go
+
 import (
 	"encoding/json"
 	"fmt"

--- a/api/server/types.go
+++ b/api/server/types.go
@@ -1,0 +1,28 @@
+package api
+
+import "github.com/runner-x/runner-x/engine/coderunner"
+
+// A LanguagesResponse contains the languages users are allowed to run on the server
+type LanguagesResponse struct {
+	Languages []coderunner.Language `json:"languages"`
+}
+
+// A RunRequest contains the data required to run used code in the CodeRunner
+// Language will not be checked by the server explicitly. The requester is responsible
+// for querying the /api/v1/languages endpoint to verify the supported languages.
+//
+// The api server should return 400 Bad Request if either of these fields are missing
+// or Language is not supported by the server.
+type RunRequest struct {
+	// TODO: document and enforce a size limit for Source string (e.g. 4K characters)
+	Source string              `json:"source"`   // Source code for CodeRunner to execute
+	Lang   coderunner.Language `json:"language"` // Programming language to compile and run the source code as
+}
+
+// A RunResponse contains the program stdout, stderr stream ouput from the code runner
+type RunResponse struct {
+	// TODO: rename and/or create new error type to wrap error types
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	Error  error  `json:"error"` // Error result from either compilation or runtime errors. Will be nil if both compilation and runtime were successful.
+}

--- a/engine/coderunner/runner.go
+++ b/engine/coderunner/runner.go
@@ -13,6 +13,14 @@ const (
 	TIMEOUT_DEFAULT = 3
 )
 
+// FileExtensionMap contains maps languages to file extensions
+// but language keys may not match the languages a user is allowed to request
+var FileExtensionMap = map[Language]string{
+	PYTHON3: "py",
+	SHELL:   "sh",
+	CPP11:   "cpp",
+}
+
 func NewCodeRunner(id, dir string) *CodeRunner {
 	r := runtime.NewTimeoutRuntime(id)
 	return &CodeRunner{runner: r, workdirPath: dir}
@@ -43,8 +51,7 @@ func (cr *CodeRunner) Run(props *RunnerProps) (*RunnerOutput, error) {
 	}(dir)
 
 	// write user input into tempdir
-	extensionMap := fileExtensionMap()
-	filename := "code." + extensionMap[props.Lang]
+	filename := "code." + FileExtensionMap[props.Lang]
 	writePath := filepath.Join(dir, filename)
 
 	print.DebugPrintf("source path: %s", writePath)
@@ -72,13 +79,6 @@ func (cr *CodeRunner) Run(props *RunnerProps) (*RunnerOutput, error) {
 		runOutput.Stderr,
 		err,
 	}, nil
-}
-
-func fileExtensionMap() map[Language]string {
-	return map[Language]string{
-		PYTHON3: "py",
-		SHELL:   "sh",
-	}
 }
 
 // TODO: refactor these into a module and handle with pre-run hooks

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ Editors:
 
 Extensions setup docs:
 
-- Writing Go in VSCode: https://code.visualstudio.com/docs/languages/go
-- Debugging Go in VSCode: https://github.com/golang/vscode-go/blob/master/docs/debugging.md
+- Writing Go in VSCode: <https://code.visualstudio.com/docs/languages/go>
+- Debugging Go in VSCode: <https://github.com/golang/vscode-go/blob/master/docs/debugging.md>
 
 Recommended extensions (VSCode):
 
@@ -84,7 +84,13 @@ make run-api
 # run the API server in the background (you'll have to shut it down later)
 make run-api-bg
 
-# kill the server if it's running (this works by killing the process using port 8080, the API port)
+# run the mock API server (blocking)
+make run-mock
+
+# run the mock API server in the background (you'll have to use `make kill-api` to shut down)
+make run-mock-bg
+
+# kill the server (mock or not) if it's running (this works by killing the process using port 8080, the API port)
 make kill-api
 
 # run all tests in the repository
@@ -135,6 +141,7 @@ cobra add childCommand -p 'parentCommand'
 - Examples:
   - [adding a command line flag to CLI](https://github.com/camerondurham/ch/blob/4bb750335485169e469bdb191c8ca29bb107b358/cmd/create.go#L171)
   - [reading what user set flag to](https://github.com/camerondurham/ch/blob/4bb750335485169e469bdb191c8ca29bb107b358/cmd/create.go#L75)
+
 ### Running the Server
 
 During CLI or even server development, you will likely want to run the server during testing.


### PR DESCRIPTION
Add server request types with minimal documentation on behavior of API.

This can be improved by adding more detail but should be sufficient to begin server request/response handling.

Also added mock server, a  copy of the existing `api/main.go` for now.