### PR TITLE
Server request error handling and fix docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ dkr-build-server:
 	docker build -t ${SERVER_NAME}:${VERSION} -f docker/server/Dockerfile .
 
 dkr-server: dkr-build-server
-	docker run -d -p 8080:8080 --name ${SERVER_NAME} ${SERVER_NAME}:${VERSION}
+	docker run -d -p 8080:8080 -e DEBUG=1 --name ${SERVER_NAME} ${SERVER_NAME}:${VERSION}
 
 dkr-stop-mock:
 	docker stop ${MOCK_SERVER_NAME}

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -3,9 +3,11 @@ WORKDIR /runner
 COPY . .
 RUN go build -v -o /runner/runner-server /runner/server/
 
-# TODO: make this from scratch
 FROM golang:1.17.6-alpine3.15
-# FROM scratch
+
+# TODO: install other runtime dependencies here
+RUN apk add python3
+
 WORKDIR /runner
 COPY --from=builder /runner/runner-server ./
 EXPOSE 8080

--- a/server/main.go
+++ b/server/main.go
@@ -39,7 +39,7 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 	// breaks when EOF reached
 	for {
 		err = decoder.Decode(&res)
-		if err != nil {
+		if err != nil && err != io.EOF {
 			throwE400(w, "failed to parse request body")
 			return
 		}
@@ -48,7 +48,12 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// TODO: transform request body into runner engine input
+	// verify request contains both language and source code to run
+	if len(res.Lang) == 0 || len(res.Source) == 0 {
+		// language and source code fields are required
+		throwE400(w, "\"language\" and \"source\" fields are required")
+		return
+	}
 
 	handler := coderunner.NewCodeRunner("api-runhandler", "")
 

--- a/server/main.go
+++ b/server/main.go
@@ -30,7 +30,6 @@ func languagesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func runHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO: parse request body
 	decoder := json.NewDecoder(r.Body)
 	var res api.RunRequest
 	var err error
@@ -50,7 +49,6 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 
 	// verify request contains both language and source code to run
 	if len(res.Lang) == 0 || len(res.Source) == 0 {
-		// language and source code fields are required
 		throwE400(w, "\"language\" and \"source\" fields are required")
 		return
 	}
@@ -62,8 +60,6 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 		Lang:   res.Lang,
 	}
 
-	// TODO: let code runner run the code
-
 	RunnerOutput, err := handler.Run(&RunProps)
 
 	if err != nil {
@@ -71,7 +67,6 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: replace hard-coded reponse with transformed runner output
 	output := api.RunResponse{
 		Stdout: RunnerOutput.Stdout,
 		Stderr: RunnerOutput.Stderr,


### PR DESCRIPTION
After some manual testing, realized the error handling logic does still need to verify that the `"language"` and `"source"` fields are not empty.

Unfortunately, Go's json.Decode won't even throw errors if not all fields are parsed correctly. I made this mistake when reviewing and suggesting in PR #46 and sending this PR to fix.

Example of what was going wrong:

```bash
# valid request classified as invalid by mistake
curl --silent -X POST -H "Content-Type: application/json" --data '{"language":"python3","source":"print(\"oh sh*t this actually kinda works\")" }' localhost:8080/api/v1/run | jq

{
  "error": "failed to parse request body"
}
```

After changes to error handling/validation:

```bash
# source and language fields are checked
curl --silent -X POST -H "Content-Type: application/json" --data '{"languageowiejfoij":"python3","sourceowiefjoiwejf":"print(\"oh sh*t this actually kinda works\")" }' localhost:8080/api/v1/run | jq

{
  "error": "\"language\" and \"source\" fields are required"
}
```

```bash
# happy case request works as expected
curl --silent -X POST -H "Content-Type: application/json" --data '{"language":"python3","source":"print(\"oh sh*t this actually kinda works\")" }' localhost:8080/api/v1/run | jq
{
  "stdout": "oh sh*t this actually kinda works\n",
  "stderr": "",
  "error": null
}
```