### PR TITLE
Add integration test and fix bug not using UID, GID in controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ all:
 	@echo ""
 	@echo "  fmt: run go fmt on the repository"
 	@echo ""
+	@echo "  clean: remove build directory"
+	@echo ""
 	@echo "  lint: run Docker golang-lint-ci for the repository"
 	@echo ""
 	@echo "  install-hooks: install git-hooks in the cloned repo .git directory"
@@ -107,6 +109,9 @@ cover: build
 
 fmt:
 	go fmt ./...
+
+clean:
+	rm -rf build
 
 lint:
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.44.0 golangci-lint run  ./... -v

--- a/engine/integ_test/integration_test.go
+++ b/engine/integ_test/integration_test.go
@@ -1,0 +1,67 @@
+package integtest
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	ctrl "github.com/runner-x/runner-x/engine/controller"
+	"github.com/runner-x/runner-x/engine/runtime"
+)
+
+// Test_ControllerRunMultipleRequests verifies that the contoller
+// actually limits the number of concurrent requests that can be made
+// at one time. This is different from the unit tests in controller_test.go
+// since we are not using mocked RuntimeAgents.
+func Test_ControllerRunMultipleRequests(t *testing.T) {
+
+	var wg sync.WaitGroup
+
+	asyncCtrl := ctrl.NewAsyncController(2, &runtime.NilProvider{})
+
+	sleepy := &runtime.RunProps{
+		RunArgs: []string{"sleep", "1"},
+		Timeout: 2,
+	}
+	go runSafeCmdAndPrintResult(asyncCtrl, sleepy, wg)
+
+	go runSafeCmdAndPrintResult(asyncCtrl, sleepy, wg)
+
+	// Let other commands run first. Unfortunately without this sleep,
+	// the SubmitRequest below will run before the goroutines have a time
+	// to execute. We want this test to verify that when all runners are
+	// occupied, the controller will return an error instead of accepting
+	// a job it has no room to do.
+	time.Sleep(time.Millisecond * 100)
+
+	runSafeCmdAndAssertControllerError(asyncCtrl, sleepy, &ctrl.ControllerRunOutput{ControllerErr: ctrl.NoRunnerIsReady}, t)
+
+	// allow other commands to finish
+	wg.Wait()
+
+	// TODO: find out why this is needed to let other jobs finish and the wait group is not sufficient
+	time.Sleep(time.Second * 1)
+
+	// run command again after the other commands have finished
+	runSafeCmdAndAssertControllerError(asyncCtrl, sleepy, &ctrl.ControllerRunOutput{ControllerErr: nil}, t)
+}
+
+func runSafeCmdAndPrintResult(ac *ctrl.AsyncController, props *runtime.RunProps, wg sync.WaitGroup) {
+	// let the test wait until this job completes
+	wg.Add(1)
+	defer wg.Done()
+	output := ac.SubmitRequest(props)
+
+	// print for debugging output
+	fmt.Printf("output: %v\n", output)
+}
+
+func runSafeCmdAndAssertControllerError(ac *ctrl.AsyncController, props *runtime.RunProps, expect *ctrl.ControllerRunOutput, t *testing.T) {
+	output := ac.SubmitRequest(props)
+	if output.ControllerErr != nil && expect.ControllerErr == nil {
+		t.Errorf("expected no controller error but got: %v", output.ControllerErr.Error())
+	} else if output.ControllerErr == nil && expect.ControllerErr != nil {
+		t.Errorf("expected controller error: \"%s\" but got: %v", expect.ControllerErr.Error(), output.ControllerErr)
+	}
+}

--- a/engine/integ_test/integration_test.go
+++ b/engine/integ_test/integration_test.go
@@ -41,7 +41,7 @@ func Test_ControllerRunMultipleRequests(t *testing.T) {
 	wg.Wait()
 
 	// TODO: find out why this is needed to let other jobs finish and the wait group is not sufficient
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 3)
 
 	// run command again after the other commands have finished
 	runSafeCmdAndAssertControllerError(asyncCtrl, sleepy, &ctrl.ControllerRunOutput{ControllerErr: nil}, t)

--- a/engine/runtime/types.go
+++ b/engine/runtime/types.go
@@ -44,8 +44,8 @@ const (
 type RunProps struct {
 	RunArgs []string `json:"run_args"` // program arguments
 	Timeout int      `json:"timeout"`  // timeout before program is killed
-	Uid     int      `json:"uid"`
-	Gid     int      `json:"gid"`
+	Uid     int      `json:"uid"`      // TODO: remove, only the runtime agent itself should care about the uid and this should be overridden
+	Gid     int      `json:"gid"`      // TODO: remove, same as above
 	Nprocs  int      `json:"nprocs"`
 }
 


### PR DESCRIPTION
1. use the agent's gid, uid variables when running commands from the controller
2. add integration test that asserts controller behavior with a sequence of requests 

The main addition of this PR is the integration test that asserts the controller behavior. The test currently only asserts that when "overloaded" (no runners available), the controller will not take more requests but when a spot is free it can take requests again.

Already closed the issue 18 but this PR actually adds an assertion on the basic acceptance criteria of #18.

TODO:

- [ ] Use AsyncController in server/coderunner instead of using default runtime (tracked in #63 )