### PR TITLE
Added url flag for deployment

### DIFF
--- a/cli/runner/cmd/langs.go
+++ b/cli/runner/cmd/langs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/runner-x/runner-x/cli/runner/client"
+	"github.com/runner-x/runner-x/engine/coderunner"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +17,18 @@ var langsCmd = &cobra.Command{
 	Use:   "langs",
 	Short: "query the server for supported languages",
 	Run: func(cmd *cobra.Command, args []string) {
-		// implement CLI subcommand logic here
-		var cmdClient client.Requester = client.NewClient()
+		url, err := rootCmd.PersistentFlags().GetString("url")
+		if err != nil {
+			panic(err)
+		}
+
+		var cmdClient client.Requester
+		clint := client.Config{
+			BaseUrl: url,
+			Timeout: coderunner.TIMEOUT_DEFAULT,
+		}
+		cmdClient = client.NewClientFromConfig(clint)
+
 		resp, err := cmdClient.Languages()
 		if err != nil {
 			fmt.Println(err)

--- a/cli/runner/cmd/root.go
+++ b/cli/runner/cmd/root.go
@@ -43,4 +43,5 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().StringP("url", "u", "http://localhost:10100", "specifies the url host for the runner API")
 }

--- a/cli/runner/cmd/run.go
+++ b/cli/runner/cmd/run.go
@@ -33,6 +33,11 @@ var runCmd = &cobra.Command{
 			panic(err)
 		}
 
+		url, err := rootCmd.PersistentFlags().GetString("url")
+		if err != nil {
+			panic(err)
+		}
+
 		filename := args[0]
 		ext := extractExtension(filename)
 		var langCheck coderunner.Language
@@ -51,7 +56,14 @@ var runCmd = &cobra.Command{
 			return
 		}
 
-		var cmdClient client.Requester = client.NewClient()
+		// add a flag to modify timeout?
+		var cmdClient client.Requester
+		clint := client.Config{
+			BaseUrl: url,
+			Timeout: coderunner.TIMEOUT_DEFAULT,
+		}
+		cmdClient = client.NewClientFromConfig(clint)
+
 		r := &api.RunRequest{
 			Source: string(source[:]),
 			Lang:   langCheck,


### PR DESCRIPTION
Just a quick edit in the CLI to allow for new deployment url 

Rather than using curl, you can use the CLI such as: 
```bash
$ runner --url http://runner.fly.dev:10100 run test-files/test.py
```